### PR TITLE
refactor(rpc): Deprecate get_block_height in favor of get_tick_info

### DIFF
--- a/qubipy/rpc/rpc_client.py
+++ b/qubipy/rpc/rpc_client.py
@@ -7,6 +7,7 @@ the interaction with the Qubic API, making HTTP requests and handling responses.
 import requests
 from typing import Dict, Any
 import json
+import warnings
 
 from qubipy.exceptions import *
 from qubipy.config import *
@@ -586,6 +587,9 @@ class QubiPy_RPC:
         """
         Retrieves the current block height from the API.
 
+        .. deprecated:: 0.4.0
+        Use :func:`get_tick_info` instead. This function will be removed in a future release.
+
         Returns:
             Dict[str, Any]: A dictionary containing the current block height. 
                             If the block height is not found, an empty dictionary is returned.
@@ -593,7 +597,12 @@ class QubiPy_RPC:
         Raises:
             QubiPy_Exceptions: If there is an issue with the API request (e.g., network error, invalid response, or timeout).
         """
-
+        warnings.warn(
+        "The 'get_block_height()' function is deprecated and will be removed in a future version of QubiPy. "
+        "Please use 'get_tick_info()' instead for future compatibility.",
+        DeprecationWarning,
+        stacklevel=2
+        )
         try:
             response = requests.get(f'{self.rpc_url}{BLOCK_HEIGHT}', headers=HEADERS, timeout=self.timeout)
             response.raise_for_status()


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to QubiPy
title: Deprecate get_block_height in favor of get_tick_info
labels: ''
assignees: ''
---

### Description
Deprecate get_block_height in favor of get_tick_info

### Related Issue
<!-- Please link to the issue here using # -->
Fixes #

### Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [x] 📚 Documentation update
- [x] 🔨 Code refactoring
- [ ] 🧪 Test updates

### Testing
<!-- Describe the tests you ran and their results -->
- [x] All tests pass
- [ ] New tests added for changes

### Checklist
<!-- Mark completed items with an [x] -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] I have updated the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass locally

### Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

### Additional Notes
<!-- Add any other context about the PR here -->